### PR TITLE
Remove Joda-Time dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,6 @@
       <artifactId>config</artifactId>
       <version>1.4.2</version>
     </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.12.0</version>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Philadelphia 2.0.0 no longer needs it.